### PR TITLE
Wip spanish ens

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
@@ -1,10 +1,18 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_wrlinux
-. /usr/share/scap-security-guide/remediation_functions
-populate var_accounts_tmout
+# platform = multi_platform_all
 
-if grep --silent ^TMOUT /etc/profile ; then
-        sed -i "s/^TMOUT.*/TMOUT=$var_accounts_tmout/g" /etc/profile
-else
-        echo -e "\n# Set TMOUT to $var_accounts_tmout per security requirements" >> /etc/profile
-        echo "TMOUT=$var_accounts_tmout" >> /etc/profile
+{{{ bash_instantiate_variables("var_accounts_tmout") }}}
+
+# if 0, no occurence of tmout found, if 1, occurence found
+tmout_found=0
+
+for f in /etc/profile /etc/profile.d/*.sh; do
+    if grep --silent -E '(readonly)?\s*TMOUT' $f; then
+        sed -i -E 's/TMOUT=[[:digit:]]+(.*)$/TMOUT='$var_accounts_tmout'\1/g' $f
+        tmout_found=1
+    fi
+done
+
+if [ $tmout_found -eq 0 ]; then
+        echo -e "\n# Set TMOUT to $var_accounts_tmout per security requirements" >> /etc/profile.d/tmout.sh
+        echo "readonly TMOUT=$var_accounts_tmout" >> /etc/profile.d/tmout.sh
 fi

--- a/rhel7/profiles/ens-server.profile
+++ b/rhel7/profiles/ens-server.profile
@@ -205,11 +205,6 @@ selections:
   - accounts_umask_etc_csh_cshrc
   - accounts_umask_interactive_users
 
-  ### FMT_MOF_EXT.1 / AC-11(a)
-  ### Set Screen Lock Timeout Period to 10 Minutes or Less
-  - accounts_tmout
-  - var_accounts_tmout=15_min
-
   #### CCN-STIC-619_Paso_7_herramientas_servicios_y_demonios_innecesarios
   ## FIXME: Sorry, I won't disable nfs
   - kernel_module_freevxfs_disabled

--- a/rhel7/profiles/ens-server.profile
+++ b/rhel7/profiles/ens-server.profile
@@ -205,6 +205,11 @@ selections:
   - accounts_umask_etc_csh_cshrc
   - accounts_umask_interactive_users
 
+  ### FMT_MOF_EXT.1 / AC-11(a)
+  ### Set Screen Lock Timeout Period to 10 Minutes or Less
+  - accounts_tmout
+  - var_accounts_tmout=15_min
+
   #### CCN-STIC-619_Paso_7_herramientas_servicios_y_demonios_innecesarios
   ## FIXME: Sorry, I won't disable nfs
   - kernel_module_freevxfs_disabled


### PR DESCRIPTION
#### Description:

- Update bash script 

#### Rationale:

- Take into account the "readonly" command, and remove the "space" regular expresion check before and after the equal sign.

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
